### PR TITLE
Add support for default amount type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ All the extension/operator functions have an associated test in [`src/test/kotli
 // Create a monetary amount of a specific type and currency
 val money = (10.0).ofCurrency<FastMoney>("EUR")
 
+// Create a monetary amount of a default type for the provider and currency.
+// If using Moneta, its default type is Money and can be changed by specifying 
+// org.javamoney.moneta.Money.defaults.amountType in the javamoney.properties.
+val money = (10.0).ofCurrency("EUR")
+//or
+val money = (10.0).ofCurrency<MonetaryAmount>("EUR")
+
 // add
 money + money
 +money

--- a/src/main/kotlin/nl/hiddewieringa/money/MonetaryExtensions.kt
+++ b/src/main/kotlin/nl/hiddewieringa/money/MonetaryExtensions.kt
@@ -36,13 +36,23 @@ fun Locale.getCurrencies(vararg providers: String): Set<CurrencyUnit> =
 fun String.asConversion(vararg providers: String): CurrencyConversion =
     MonetaryConversions.getConversion(this, *providers)
 
+
+private val defaultAmountType: Class<out MonetaryAmount> = Monetary.getDefaultAmountType()
+
 /**
  * @see Monetary.getAmountFactory
  */
+@Suppress("UNCHECKED_CAST")
 fun <T : MonetaryAmount> monetaryAmount(type: Class<T>, init: MonetaryAmountFactory<T>.() -> Unit = {}): T =
-    Monetary.getAmountFactory(type)
-        .apply(init)
-        .create()
+    when (type) {
+        MonetaryAmount::class.java -> defaultAmountType as Class<T>
+        else -> type
+    }
+        .let {
+            Monetary.getAmountFactory(it)
+                .apply(init)
+                .create()
+        }
 
 /**
  * @see Monetary.getAmountFactories

--- a/src/test/kotlin/nl/hiddewieringa/money/MonetaryExtensionsTest.kt
+++ b/src/test/kotlin/nl/hiddewieringa/money/MonetaryExtensionsTest.kt
@@ -2,6 +2,7 @@ package nl.hiddewieringa.money
 
 import nl.hiddewieringa.money.format.amountFormatQuery
 import org.javamoney.moneta.FastMoney
+import org.javamoney.moneta.Money
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Disabled
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.*
 import javax.money.Monetary
+import javax.money.MonetaryAmount
 import javax.money.UnknownCurrencyException
 
 class MonetaryExtensionsTest {
@@ -56,17 +58,52 @@ class MonetaryExtensionsTest {
     }
 
     @Test
+    fun `default monetary amount`() {
+        with(monetaryAmount<MonetaryAmount> { setNumber(10); setCurrency("EUR") }) {
+            assertNotNull(this)
+            assertEquals(this::class, Money::class)
+        }
+
+        with(monetaryAmount(MonetaryAmount::class.java) { setNumber(10); setCurrency("EUR") }) {
+            assertNotNull(this)
+            assertEquals(this::class, Money::class)
+        }
+
+        with(10.ofCurrency<MonetaryAmount>("EUR")) {
+            assertNotNull(this)
+            assertEquals(this::class, Money::class)
+        }
+
+        with(10.ofCurrency<MonetaryAmount>("EUR".asCurrency())) {
+            assertNotNull(this)
+            assertEquals(this::class, Money::class)
+        }
+
+        assertNotNull(10.ofCurrency("EUR"))
+        assertNotNull(10.ofCurrency("EUR".asCurrency()))
+    }
+
+    @Test
     fun `monetary amount`() {
-        assertNotNull(monetaryAmount<FastMoney> {
-            setNumber(10)
-            setCurrency("EUR")
-        })
-        assertNotNull(monetaryAmount(FastMoney::class.java) {
-            setNumber(10)
-            setCurrency("EUR")
-        })
-        assertNotNull(10.ofCurrency<FastMoney>("EUR"))
-        assertNotNull(10.ofCurrency<FastMoney>("EUR".asCurrency()))
+        with(monetaryAmount<FastMoney> { setNumber(10); setCurrency("EUR") }) {
+            assertNotNull(this)
+            assertEquals(this::class, FastMoney::class)
+        }
+
+        with(monetaryAmount(FastMoney::class.java) { setNumber(10); setCurrency("EUR") }) {
+            assertNotNull(this)
+            assertEquals(this::class, FastMoney::class)
+        }
+
+        with(10.ofCurrency<FastMoney>("EUR")) {
+            assertNotNull(this)
+            assertEquals(this::class, FastMoney::class)
+        }
+
+        with(10.ofCurrency<FastMoney>("EUR".asCurrency())) {
+            assertNotNull(this)
+            assertEquals(this::class, FastMoney::class)
+        }
     }
 
     @Test


### PR DESCRIPTION
Addresses default type support discussed in https://github.com/hiddewie/money-kotlin/issues/3